### PR TITLE
Fix server blocking issue after processing several requests upon startup

### DIFF
--- a/client/src/toolsManager.py
+++ b/client/src/toolsManager.py
@@ -56,8 +56,6 @@ def startServer(
             isServerStarted = True
             toolSignals.serverStarted.emit()
         yield isServerStarted
-        if isServerStarted:
-            break
     logPath = logOutputPath
 
 


### PR DESCRIPTION
I noticed that in the `asyncSubprocessManager` class within the `PyEasyUtils` library, `asyncio.subprocess.PIPE` is used to redirect output. In the `startServer` function, the monitoring loop exits immediately upon detecting the server startup success string. This causes the output reading to stop, resulting in the pipeline buffer not being cleared and eventually blocking the child process when writing output.
To address this, I implemented a small trick to keep the pipeline buffer clean: I removed the `break` statement while retaining the signal transmission. This allows the monitoring loop to continue running until the program exits, ensuring the buffer remains clear.