### PR TITLE
Prevent main process from surviving when window is closed before server starts

### DIFF
--- a/client/src/functions.py
+++ b/client/src/functions.py
@@ -490,6 +490,25 @@ class TaskStatus:
     Succeeded = 'Succeeded'
 
 
+areTasksEnded: bool = True
+
+def _updateAreTasksEnded(val):
+    global areTasksEnded
+    areTasksEnded = val
+
+functionSignals.taskStatus.connect(lambda executeMethodName, taskStatus: _updateAreTasksEnded(False) if taskStatus == TaskStatus.Started else None)
+functionSignals.tasksEnded.connect(lambda: _updateAreTasksEnded(True))
+
+
+forceQuit: bool = False
+
+def _updateForceQuit(val):
+    global forceQuit
+    forceQuit = val
+
+functionSignals.forceQuit.connect(lambda: _updateForceQuit(True))
+
+
 class WorkerManager(QWorker.WorkerManager):
     tasks: dict = {}
     endAllTasks: bool = False

--- a/client/src/toolsManager.py
+++ b/client/src/toolsManager.py
@@ -22,6 +22,16 @@ class CustomSignals_Tools(QObject):
 toolSignals = CustomSignals_Tools()
 
 
+isServerEnded: bool = True
+
+def _updateIsServerEnded(val):
+    global isServerEnded
+    isServerEnded = val
+
+toolSignals.serverStarted.connect(lambda: _updateIsServerEnded(False))
+toolSignals.serverEnded.connect(lambda: _updateIsServerEnded(True))
+
+
 host = None
 port = None
 logPath = None


### PR DESCRIPTION
- Add forceQuit flag check to prevent main process from surviving when window is closed before server starts
- Refactor task and server status flags to global variables with improved assignment logic
- Simplify endEvent() slot function