### PR TITLE
Rename infoLogger

### DIFF
--- a/server/utils/logger.py
+++ b/server/utils/logger.py
@@ -11,7 +11,7 @@ logDir = Path(currentDir).joinpath('logs').as_posix()
 logger = loggerManager()
 
 infoLogger = logger.createLogger(
-    name = "router",
+    name = "info",
     level = "INFO",
     outputPath = Path(logDir).joinpath("server.log"),
 )


### PR DESCRIPTION
Rename infoLogger from 'router' to 'info' since middleware also affects the app APIs.